### PR TITLE
Correct args.loginfile

### DIFF
--- a/zbx-hpmsa.py
+++ b/zbx-hpmsa.py
@@ -712,7 +712,7 @@ if __name__ == '__main__':
 
     # Make login hash string
     if args.login_file:
-        CRED_HASH = make_pwd_hash(args.loginfile, isfile=True)
+        CRED_HASH = make_pwd_hash(args.login_file, isfile=True)
     else:
         CRED_HASH = make_pwd_hash('_'.join([args.user, args.password]))
 


### PR DESCRIPTION
Hi!

In line 715 there is little mistake:

CRED_HASH = make_pwd_hash(**args.loginfile**, isfile=True)

but it must be:

CRED_HASH = make_pwd_hash(**args.login_file**, isfile=True)