### PR TITLE
Value Map was missing for the disk-group health status item.

### DIFF
--- a/Template HPE MSA for Zabbix 4.0.xml
+++ b/Template HPE MSA for Zabbix 4.0.xml
@@ -1679,7 +1679,9 @@ But, in my case it's lies. &quot;Redundant&quot; equals &quot;2&quot;.&#13;
                             <description>Disk group {#DG.ID} with type {#DG.TYPE} health status (numeric).</description>
                             <inventory_link>0</inventory_link>
                             <applications/>
-                            <valuemap/>
+                            <valuemap>
+                                <name>HPE MSA Disk Health</name>
+                            </valuemap>
                             <logtimefmt/>
                             <preprocessing>
                                 <step>


### PR DESCRIPTION
The latest data for the "MSA Disk group $name" "Disk group $name health status, numeric" item was simply an integer. I compared the specs for this item in the "HP MSA 1040 - CLI Reference Guide" wit the already defined value maps in this template, and the "HPE MSA Disk Health" value map matches.