### PR TITLE
Fix item "Enclosure {#ENCLOSURE.ID} operational status" had incorrect value

### DIFF
--- a/Template HPE MSA for Zabbix 4.0 with SSL.xml
+++ b/Template HPE MSA for Zabbix 4.0 with SSL.xml
@@ -3010,7 +3010,7 @@ Ack to close.</description>
                             <preprocessing>
                                 <step>
                                     <type>12</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                 </step>
                             </preprocessing>
                             <jmx_endpoint/>

--- a/Template HPE MSA for Zabbix 4.0.xml
+++ b/Template HPE MSA for Zabbix 4.0.xml
@@ -3010,7 +3010,7 @@ Ack to close.</description>
                             <preprocessing>
                                 <step>
                                     <type>12</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                 </step>
                             </preprocessing>
                             <jmx_endpoint/>

--- a/Template HPE MSA for Zabbix 4.2 with SSL.xml
+++ b/Template HPE MSA for Zabbix 4.2 with SSL.xml
@@ -3057,7 +3057,7 @@ Ack to close.</description>
                             <preprocessing>
                                 <step>
                                     <type>12</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                     <error_handler>0</error_handler>
                                     <error_handler_params/>
                                 </step>

--- a/Template HPE MSA for Zabbix 4.2.xml
+++ b/Template HPE MSA for Zabbix 4.2.xml
@@ -3057,7 +3057,7 @@ Ack to close.</description>
                             <preprocessing>
                                 <step>
                                     <type>12</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                     <error_handler>0</error_handler>
                                     <error_handler_params/>
                                 </step>

--- a/Template HPE MSA for Zabbix 4.4 with SSL.xml
+++ b/Template HPE MSA for Zabbix 4.4 with SSL.xml
@@ -1533,7 +1533,7 @@ Disk model: {#DISK.MODEL}</description>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                 </step>
                             </preprocessing>
                             <master_item>

--- a/Template HPE MSA for Zabbix 4.4.xml
+++ b/Template HPE MSA for Zabbix 4.4.xml
@@ -1534,7 +1534,7 @@ Disk model: {#DISK.MODEL}</description>
                             <preprocessing>
                                 <step>
                                     <type>JSONPATH</type>
-                                    <params>$['{#ENCLOSURE.ID}']['h']</params>
+                                    <params>$['{#ENCLOSURE.ID}']['s']</params>
                                 </step>
                             </preprocessing>
                             <master_item>


### PR DESCRIPTION
Because of mistake in preprocessing this item incorrectly contained
value for `Enclosure {#ENCLOSURE.ID} health status`.