### PR TITLE
Fix TMP_DIR as string

### DIFF
--- a/zbx-hpmsa.py
+++ b/zbx-hpmsa.py
@@ -647,7 +647,7 @@ if __name__ == '__main__':
     args = main_parser.parse_args()
 
     API_VERSION = args.api
-    TMP_DIR = args.tmp_dir
+    TMP_DIR = "".join(args.tmp_dir)
     CACHE_DB = TMP_DIR.rstrip('/') + '/zbx-hpmsa.cache.db'
 
     if args.command in ('lld', 'full'):


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/zabbix/externalscripts/zbx-hpmsa.py", line 652, in <module>
    CACHE_DB = TMP_DIR.rstrip('/') + '/zbx-hpmsa.cache.db'
AttributeError: 'list' object has no attribute 'rstrip'

TMP_DIR need to be a string.